### PR TITLE
🍺feat(error): added error module

### DIFF
--- a/finch/src/app.js
+++ b/finch/src/app.js
@@ -5,6 +5,8 @@ import config from '../config/index.js';
 
 import ReceiptController from './modules/books/controller.js';
 
+import CatchController from './middlewares/catch-controller.js';
+
 import HttpServer from './http-server.js';
 import Database from './services/database.js';
 
@@ -22,9 +24,10 @@ const server = new HttpServer({
 
 const database = new Database(config.database);
 
-
 server.start();
 
 database.connect();
 
 new ReceiptController({ app: server.app }).initRoutes();
+
+new CatchController({ app: server.app }).init();

--- a/finch/src/error/__tests__/app-error.test.js
+++ b/finch/src/error/__tests__/app-error.test.js
@@ -1,0 +1,25 @@
+import AppError, { DB_OPERATIONS_ERROR } from '../app-error.js';
+
+describe('AppError', () => {
+  describe('#constructor', () => {
+    test('should assign errorCode sent in argument to as its property', () => {
+      const appError = new AppError('RANDOM_ERROR_CODE');
+      expect(appError.errorCode).toBe('RANDOM_ERROR_CODE');
+    });
+
+    test('should public message as its property if passed', () => {
+      const appError = new AppError(null, 'Random Error msg');
+      expect(appError.publicMessage).toBe('Random Error msg');
+    });
+
+    test('should assign default publicMessage according to error code', () => {
+      const appError = new AppError(DB_OPERATIONS_ERROR);
+      expect(appError.publicMessage).toBe('Error while executing Database operations');
+    });
+
+    test('should assign httpStatusCode according to errorCode', () => {
+      const appError = new AppError(DB_OPERATIONS_ERROR);
+      expect(appError.httpStatusCode).toBe(500);
+    });
+  });
+});

--- a/finch/src/error/__tests__/error-maps.test.js
+++ b/finch/src/error/__tests__/error-maps.test.js
@@ -1,0 +1,35 @@
+import * as errorCodes from '../app-error.js';
+import {
+  defaultPublicMessages,
+  httpStatusCodeMap,
+} from '../error-maps.js';
+
+describe('erroCodes', () => {
+    const errors = Object
+      .keys(errorCodes)
+      .filter(err => err !== 'default');
+
+  describe('defaultPublicMessages', () => {
+    describe('should contain default public message for each ', () => {
+      test.each(errors)('%p', (code) => {
+        const publicMessage = defaultPublicMessages[code];
+
+        expect(typeof publicMessage).toBe('string');
+        expect(publicMessage).toBeTruthy();
+      });
+    });
+  });
+
+  describe('httpStatusMap', () => {
+    describe('should contain default public message for each ', () => {
+      test.each(errors)('%p', (code) => {
+        const statusCode = httpStatusCodeMap[code];
+
+        expect(typeof statusCode).toBe('number');
+        expect(statusCode).toBeTruthy();
+      });
+    });
+  });
+
+
+});

--- a/finch/src/error/app-error.js
+++ b/finch/src/error/app-error.js
@@ -1,0 +1,14 @@
+import { defaultPublicMessages, httpStatusCodeMap } from './error-maps.js';
+
+export default class AppError extends Error {
+  constructor(errorCode, publicMessage) {
+    super();
+    this.errorCode = errorCode;
+    this.publicMessage = publicMessage || defaultPublicMessages[errorCode];
+    this.httpStatusCode = httpStatusCodeMap[errorCode];
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export const DB_OPERATIONS_ERROR = 'DB_OPERATIONS_ERROR';

--- a/finch/src/error/error-maps.js
+++ b/finch/src/error/error-maps.js
@@ -1,0 +1,9 @@
+import { INTERNAL_SERVER_ERROR } from "../http/status-codes.js";
+
+export const httpStatusCodeMap = {
+  DB_OPERATIONS_ERROR: INTERNAL_SERVER_ERROR,
+};
+
+export const defaultPublicMessages = {
+  DB_OPERATIONS_ERROR: 'Error while executing Database operations',
+};

--- a/finch/src/http/status-codes.js
+++ b/finch/src/http/status-codes.js
@@ -1,0 +1,12 @@
+/* HTTP Code Constant */
+export const HTTP_RESOURCE_CREATED = 201;
+export const HTTP_OK = 200;
+
+export const BAD_REQUEST = 400;
+export const RESOURCE_NOT_FOUND = 404;
+export const UNAUTHORIZED = 401;
+export const FORBIDDEN = 403;
+
+
+// Server Errors
+export const INTERNAL_SERVER_ERROR = 500;

--- a/finch/src/middlewares/__tests__/catch-controller.test.js
+++ b/finch/src/middlewares/__tests__/catch-controller.test.js
@@ -1,0 +1,50 @@
+import httpMocks from 'node-mocks-http';
+
+import CatchController from '../catch-controller.js';
+
+describe('CatchController', () => {
+  describe('#constructor', () => {
+    test('should assign passed app argument as its app property', () => {
+      const app = { mockApp: true };
+      const controller = new CatchController({ app });
+      expect(controller.app).toStrictEqual({ mockApp: true });
+    });
+  });
+
+  describe('#handleError', () => {
+    test('should call respond with error object', () => {
+      const mockReq = httpMocks.createRequest();
+      const mockRes = httpMocks.createResponse();
+
+      const mockError = {
+        publicMessage: 'mock error message',
+        httpStatusCode: 400,
+        errorCode: 'MOCK_ERROR_CODE',
+      };
+
+      (new CatchController({})).handleError(mockError, mockReq, mockRes);
+      expect(mockRes.statusCode).toBe(400);
+      expect(mockRes._isJSON()).toBe(true);
+      expect(mockRes._isEndCalled()).toBe(true);
+      expect(mockRes._getJSONData()).toStrictEqual({
+        error: {
+            description: 'mock error message',
+            code: 'MOCK_ERROR_CODE',
+          },
+      });
+    });
+  });
+
+  describe('#init', () => {
+    test('should call use method of with handleError function', () => {
+      const mockApp = {
+        use: jest.fn(),
+      };
+
+      const controller = new CatchController({ app: mockApp });
+      controller.init();
+
+      expect(mockApp.use).toBeCalledTimes(1);
+    });
+  });
+});

--- a/finch/src/middlewares/catch-controller.js
+++ b/finch/src/middlewares/catch-controller.js
@@ -13,7 +13,6 @@ export default class CatchController extends HttpController {
    * For more 👉 https://expressjs.com/en/guide/error-handling.html
    */
   handleError(error, _request, response, _next) {
-    console.log({error}, 'from handle error');
     const {
       publicMessage,
       httpStatusCode: status,

--- a/finch/src/middlewares/catch-controller.js
+++ b/finch/src/middlewares/catch-controller.js
@@ -1,0 +1,34 @@
+import HttpController from '../modules/base/http-controller.js';
+
+export default class CatchController extends HttpController {
+  constructor({ app }) {
+    super();
+    this.app = app;
+  }
+
+  /**
+   * Following function needs four arguments,
+   * without them express won't consider it for catching errors
+   *
+   * For more 👉 https://expressjs.com/en/guide/error-handling.html
+   */
+  handleError(error, _request, response, _next) {
+    console.log({error}, 'from handle error');
+    const {
+      publicMessage,
+      httpStatusCode: status,
+      errorCode,
+    } = error;
+
+    const errorData = {
+      description: publicMessage,
+      code: errorCode,
+    };
+
+    this.respondWithError({ errorData, status, response });
+  }
+
+  init() {
+    this.app.use(this.handleError.bind(this));
+  }
+}

--- a/finch/src/modules/base/__tests__/crud-controller.test.js
+++ b/finch/src/modules/base/__tests__/crud-controller.test.js
@@ -99,6 +99,7 @@ describe('CrudController', () => {
       const app = express();
       const controller = new CrudController({ app });
       controller.baseRoute = '/test';
+      controller.handleException = jest.fn();
       controller.router.post = jest.fn();
       controller.router.get = jest.fn();
       controller.router.patch = jest.fn();
@@ -107,11 +108,11 @@ describe('CrudController', () => {
 
       expect(controller.router.post).toHaveBeenCalledTimes(1);
       expect(controller.router.post.mock.calls[0][0]).toBe('/test');
-      expect(controller.router.post.mock.calls[0][1].name).toBe('bound create');
+      expect(controller.handleException.mock.calls[0][0].name).toBe('bound create');
 
       expect(controller.router.get).toHaveBeenCalledTimes(2);
       expect(controller.router.get.mock.calls[0][0]).toBe('/test/:id');
-      expect(controller.router.get.mock.calls[0][1].name).toBe('bound getById');
+      expect(controller.handleException.mock.calls[1][0].name).toBe('bound getById');
       expect(controller.router.get.mock.calls[1][0]).toBe('/test');
       expect(controller.router.get.mock.calls[1][1].name).toBe('bound list');
 

--- a/finch/src/modules/base/__tests__/crud-controller.test.js
+++ b/finch/src/modules/base/__tests__/crud-controller.test.js
@@ -121,4 +121,32 @@ describe('CrudController', () => {
 
     });
   });
+
+  describe('#handleException', () => {
+    test('should return a callback which returns passed callback in return value, ', () => {
+      const mockControllerFn = jest.fn().mockReturnValue(new Promise(() => {}));
+
+      const req = { mockReq: true };
+      const res = { mockRes: true };
+      crudController.handleException(mockControllerFn)(req, res);
+
+      expect(mockControllerFn).toHaveBeenCalledTimes(1);
+      expect(mockControllerFn).toHaveBeenCalledWith(req, res);
+
+    });
+
+    test('should  call next callback when controller rejects', () => {
+      const mockCatch = jest.fn();
+      const mockControllerFn = jest
+        .fn()
+        .mockReturnValue({ catch: mockCatch });
+      const mockNext = jest.fn();
+
+      crudController
+        .handleException(mockControllerFn)({}, {}, mockNext);
+
+      expect(mockCatch).toHaveBeenCalledWith(mockNext);
+
+    });
+  });
 });

--- a/finch/src/modules/base/__tests__/http-controller.test.js
+++ b/finch/src/modules/base/__tests__/http-controller.test.js
@@ -42,7 +42,7 @@ describe('HTTPController', () => {
       };
 
       controller.respondWithError({
-        error: sampleError,
+        errorData: sampleError,
         status: 400,
         response: mockResp,
       });
@@ -50,10 +50,13 @@ describe('HTTPController', () => {
       expect(mockResp.statusCode).toBe(400);
       expect(mockResp._isJSON()).toBe(true);
       expect(mockResp._isEndCalled()).toBe(true);
+
       expect(mockResp._getJSONData()).toStrictEqual({
-        success: false,
-        error: sampleError,
+        error: {
+          msg: 'Some error message',
+        },
       });
+
     });
   });
 

--- a/finch/src/modules/base/crud-controller.js
+++ b/finch/src/modules/base/crud-controller.js
@@ -35,11 +35,17 @@ export default class CrudController extends HttpController {
     this.respondInJson({ status: 200, response });
   }
 
+  handleException(controller) {
+    return (req, res, next) => {
+      controller(req, res).catch(next);
+    }
+  }
+
   initRoutes() {
     const idRoute = getIdRoute(this.baseRoute);
 
-    this.router.post(this.baseRoute, this.create.bind(this));
-    this.router.get(idRoute, this.getById.bind(this));
+    this.router.post(this.baseRoute, this.handleException(this.create.bind(this)));
+    this.router.get(idRoute, this.handleException(this.getById.bind(this)));
     this.router.get(this.baseRoute, this.list.bind(this));
     this.router.patch(idRoute, this.update.bind(this));
 

--- a/finch/src/modules/base/http-controller.js
+++ b/finch/src/modules/base/http-controller.js
@@ -8,10 +8,9 @@ export default class HttpController {
       .json(data);
   }
 
-  respondWithError({ error = {}, status, response }) {
+  respondWithError({ errorData = {}, status, response }) {
     const data = {
-      error,
-      success: false,
+      error: errorData,
     };
 
     this.respondInJson({ data,  status, response });

--- a/finch/src/modules/books/service.js
+++ b/finch/src/modules/books/service.js
@@ -1,3 +1,4 @@
+import AppError, { DB_OPERATIONS_ERROR } from '../../error/app-error.js';
 import EmailService from '../../services/email.js';
 
 import Book from './repository.js';
@@ -25,7 +26,7 @@ export default class BooksService {
       return book.toPublicObject();
 
     } catch (error) {
-      throw new Error(error);
+      throw new AppError(DB_OPERATIONS_ERROR);
     }
   }
 


### PR DESCRIPTION
Added a central error handling module which includes following components

- `CatchController` - Express based middleware, which catches errors raised from any controller & then passed to `next` function from the controller
- `AppError` - A custom Error class, to be used across applications to handle all kinds of errors
- Error Codes - Unique constants, defined for each error & to be used to determine certain other parameters mentioned below while handling errors
- Error Maps -Two objects containing default public description or http response status codes against the error codes to be sent in http response 
- `handleException()` in `CrudController` - this methods adds the exception handling functionalities to controller by forwarding the error to `next` callback

Other extra things
- status codes - A file full of http status codes as constants
- Minor refactoring in `HttpController#respondWithError()`
- Throwing error using `AppError` in `BookService#create()`


Fixes https://github.com/anshulsahni/easy-raseed/issues/10